### PR TITLE
refactor: accept just targets as inputs and change concierge workaround and installs

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -21,6 +21,11 @@ on:
         default: false
         required: false
         type: boolean
+      just-targets:
+        description: "JSON list of just targets to run for the module under test"
+        default: '["test"]'
+        required: false
+        type: string
       timeout-minutes:
         description: "Timeout (in minutes) for the apply job"
         default: 60
@@ -71,9 +76,13 @@ jobs:
         run: just lint
 
   apply:
-    name: Terraform apply
+    name: Terraform apply (${{ matrix.just-target }})
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    strategy:
+      matrix:
+        just-target: ${{ fromJSON(inputs.just-test-targets) }}
+      fail-fast: false
     defaults:
       run:
         working-directory: ${{ inputs.module-directory }}
@@ -86,16 +95,9 @@ jobs:
         run: |
           set -e
 
-          sudo apt-get purge $(dpkg -l | grep -i docker | awk '{print $2}')
-          sudo apt-get purge containerd.io
-          sudo rm -r /run/containerd
-
           sudo snap install concierge --classic
 
-          sudo snap install terraform --classic
-          sudo snap install just --classic
-
-          sudo -E concierge prepare -p k8s
+          sudo -E concierge prepare -p k8s --extra-snaps="terraform,just"
 
           # FIXME: Install via goss snap whenever available
           goss_base_url="https://github.com/goss-org/goss/releases/latest/download"
@@ -117,4 +119,4 @@ jobs:
           sudo snap start docker
 
       - name: Run terraform apply
-        run: just test
+        run: just ${{ matrix.just-test-target }}

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -119,4 +119,4 @@ jobs:
           sudo snap start docker
 
       - name: Run terraform apply
-        run: just ${{ matrix.just-test-target }}
+        run: just ${{ matrix.just-target }}

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     strategy:
       matrix:
-        just-target: ${{ fromJSON(inputs.just-test-targets) }}
+        just-target: ${{ fromJSON(inputs.just-targets) }}
       fail-fast: false
     defaults:
       run:


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

This commit enables consumers of this workflow to pass just targets as inputs to allow bigger test frameworks to run with this workflow. It leaves test as default value to keep backwards compatibility. This commit also refactors the concierge command a bit and removes the containerd workaround as it is not needed anymore.


---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Verify SBOM is generatred correctly
2. Confirm secscan results are uploaded or logged
3. Check github actions workflow status and logs
-->

Running in https://github.com/canonical/charmed-airflow-solutions/pull/5

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Documentation updated
- [ ] SBOM generated and validated
- [ ] Secscan results reviewed
- [ ] CI workflow tested manually

